### PR TITLE
Canonicalise Imgur URLs to use MP4 format

### DIFF
--- a/web/src/components/RecordCard.tsx
+++ b/web/src/components/RecordCard.tsx
@@ -29,8 +29,12 @@ function isYoutube(gif: string): boolean {
     return gif.includes("youtu.be") || gif.includes("youtube.com")
 }
 
+function isImgur(gif: string): boolean {
+    return gif.includes("imgur")
+}
+
 function getVideoType(gif: string): "video" | "iframe" | "img" {
-    if (gif.endsWith(".mp4") || gif.endsWith(".webm")) {
+    if (gif.endsWith(".mp4") || gif.endsWith(".webm") || isImgur(gif)) {
         return "video"
     } else if (isYoutube(gif)) {
         return "iframe"
@@ -42,6 +46,8 @@ function getVideoType(gif: string): "video" | "iframe" | "img" {
 function getVideoUrl(gif: string) {
     if (isYoutube(gif)) {
         return gif.replace(/.+\/(\w+)(?:\\?.+)?$/, "https://youtube.com/embed/$1")
+    } else if (isImgur(gif)) {
+        return gif.replace(/.+\/(\w+)(\..*)?/, "https://i.imgur.com/$1.mp4")
     } else {
         return gif
     }


### PR DESCRIPTION
For future reference: this forces folders of images to be a single MP4. The rationale being that it is far more likely that users will submit folders rather than two solutions sharing the same metrics. 

My recommendation should such a situation occur in the future, to handle it as a special case. 