### PR TITLE
Split Puzzles into Subcategories

### DIFF
--- a/web/src/fragments/Sidebar.tsx
+++ b/web/src/fragments/Sidebar.tsx
@@ -27,13 +27,14 @@ import Category from "../model/Category"
 import { Link, useMatch } from "react-router-dom"
 import ApiResource from "../utils/ApiResource"
 
-function Groups() {
+function Campaign() {
     const match = useMatch("/puzzles/*")
-
+    const CampaignChapters = ["CHAPTER_1", "CHAPTER_2", "CHAPTER_3", "CHAPTER_4",
+                              "CHAPTER_5", "CHAPTER_PRODUCTION"]
     return (
         <List>
             <ExpandableListItem
-                title={"Puzzles"}
+                title={"Campaign Puzzles"}
                 icon={<Extension />}
                 content={ApiResource<Puzzle[]>({
                     url: "/om/puzzles",
@@ -47,7 +48,80 @@ function Groups() {
                                         return acc
                                     }, new Map())
                                     .entries(),
-                            ].map(([group, puzzles]) => (
+                            ].filter(([group, _]) => (CampaignChapters.includes(group)))
+                            .map(([group, puzzles]) => (
+                                <Puzzles group={puzzles[0].group} puzzles={puzzles} key={group} sx={{ pl: 4 }} />
+                            ))}
+                        </>
+                    ),
+                })}
+                open={match !== null}
+            />
+        </List>
+    )
+}
+
+function Journal() {
+    const match = useMatch("/puzzles/*")
+    const JournalChapters = ["JOURNAL_I", "JOURNAL_II", "JOURNAL_III", "JOURNAL_IV",
+                             "JOURNAL_V", "JOURNAL_VI", "JOURNAL_VII", "JOURNAL_VIII",
+                             "JOURNAL_IX"]
+    return (
+        <List>
+            <ExpandableListItem
+                title={"Journal Puzzles"}
+                icon={<Extension />}
+                content={ApiResource<Puzzle[]>({
+                    url: "/om/puzzles",
+                    element: (puzzles) => (
+                        <>
+                            {[
+                                ...puzzles
+                                    .reduce<Map<string, Puzzle[]>>((acc, puzzle) => {
+                                        if (!acc.has(puzzle.group.id)) acc.set(puzzle.group.id, [puzzle])
+                                        else acc.get(puzzle.group.id)!.push(puzzle)
+                                        return acc
+                                    }, new Map())
+                                    .entries(),
+                            ].filter(([group, _]) => (JournalChapters.includes(group)))
+                            .map(([group, puzzles]) => (
+                                <Puzzles group={puzzles[0].group} puzzles={puzzles} key={group} sx={{ pl: 4 }} />
+                            ))}
+                        </>
+                    ),
+                })}
+                open={match !== null}
+            />
+        </List>
+    )
+}
+
+function Community() {
+    const match = useMatch("/puzzles/*")
+    const CampaignChapters = ["CHAPTER_1", "CHAPTER_2", "CHAPTER_3", "CHAPTER_4",
+                              "CHAPTER_5", "CHAPTER_PRODUCTION"]
+    const JournalChapters = ["JOURNAL_I", "JOURNAL_II", "JOURNAL_III", "JOURNAL_IV",
+                             "JOURNAL_V", "JOURNAL_VI", "JOURNAL_VII", "JOURNAL_VIII",
+                             "JOURNAL_IX"]
+    return (
+        <List>
+            <ExpandableListItem
+                title={"Community Puzzles"}
+                icon={<Extension />}
+                content={ApiResource<Puzzle[]>({
+                    url: "/om/puzzles",
+                    element: (puzzles) => (
+                        <>
+                            {[
+                                ...puzzles
+                                    .reduce<Map<string, Puzzle[]>>((acc, puzzle) => {
+                                        if (!acc.has(puzzle.group.id)) acc.set(puzzle.group.id, [puzzle])
+                                        else acc.get(puzzle.group.id)!.push(puzzle)
+                                        return acc
+                                    }, new Map())
+                                    .entries(),
+                            ].filter(([group, _]) => (!CampaignChapters.includes(group) && !JournalChapters.includes(group)))
+                            .map(([group, puzzles]) => (
                                 <Puzzles group={puzzles[0].group} puzzles={puzzles} key={group} sx={{ pl: 4 }} />
                             ))}
                         </>
@@ -121,7 +195,9 @@ export default function Sidebar() {
     // noinspection HtmlUnknownTarget
     return (
         <>
-            <Groups />
+            <Campaign />
+            <Journal />
+            <Community />
             <Divider />
             <Categories />
             <Box sx={{ flexGrow: 1 }} />

--- a/web/src/fragments/Sidebar.tsx
+++ b/web/src/fragments/Sidebar.tsx
@@ -28,7 +28,7 @@ import { Link, useMatch } from "react-router-dom"
 import ApiResource from "../utils/ApiResource"
 
 function Campaign() {
-    const match = useMatch("/puzzles/*")
+    const match = useMatch("/puzzles/[P007|P010|P009|P011|P013|P008|P012|P014|P015|P016|P019|P018|P017|P020|P021|P022|P024|P025|P026|P027|P028|P030b|P029|P031b|P034|P033|P032|P036|P035|P037|P038|P042|P039|P040|P041|P043|P076|P080|P075|P074|P083|P078|P079|P081|P082|P077|P084]/*")
     const CampaignChapters = ["CHAPTER_1", "CHAPTER_2", "CHAPTER_3", "CHAPTER_4",
                               "CHAPTER_5", "CHAPTER_PRODUCTION"]
     return (
@@ -62,7 +62,7 @@ function Campaign() {
 }
 
 function Journal() {
-    const match = useMatch("/puzzles/*")
+    const match = useMatch("/puzzles/[P054|P055|P056|P057|P058|P059|P060|P061|P062|P063|P064|P065|P066|P067|P068|P069|P070|P071|P072|P086|P088|P085|P087|P089|P091b|P090|P092|P093|P094|P096|P095|P097|P098|P099|P100|P101|P102|P104|P103|P106|P105|P109|P108|P107]/*")
     const JournalChapters = ["JOURNAL_I", "JOURNAL_II", "JOURNAL_III", "JOURNAL_IV",
                              "JOURNAL_V", "JOURNAL_VI", "JOURNAL_VII", "JOURNAL_VIII",
                              "JOURNAL_IX"]
@@ -97,7 +97,7 @@ function Journal() {
 }
 
 function Community() {
-    const match = useMatch("/puzzles/*")
+    const match = useMatch("/puzzles/w*")
     const CampaignChapters = ["CHAPTER_1", "CHAPTER_2", "CHAPTER_3", "CHAPTER_4",
                               "CHAPTER_5", "CHAPTER_PRODUCTION"]
     const JournalChapters = ["JOURNAL_I", "JOURNAL_II", "JOURNAL_III", "JOURNAL_IV",


### PR DESCRIPTION
This is a proposal to split the puzzles into three tabs, Campaign, Journal and Community. This is to facilitate adding Weeklies and other events (like Speed Solves) into the leaderboard, without making the list too long proving unwieldy. The proposed UI looks like this.

Note that the campaign and journal puzzles will no longer receive further updates, thus fixing their sizes.

![2022-09-27-17:45:27-screenshot](https://user-images.githubusercontent.com/20557013/192494778-0253296c-ed32-497e-97b8-fbe41874aa2a.png)
