### PR TITLE
Add button to download puzzle file

### DIFF
--- a/web/src/views/om/puzzles/PuzzleView.tsx
+++ b/web/src/views/om/puzzles/PuzzleView.tsx
@@ -102,27 +102,50 @@ export default function PuzzleView() {
                     <LoadingIndicator />
                 )}
                 {puzzleId?.match(/w[0-9]+/) ? (
-                    <Button
-                        size="small"
-                        variant="outlined"
-                        color="primary"
-                        style={{
-                            marginTop: "auto",
-                            marginBottom: "auto",
-                        }}
-                    >
-                        <a
-                            href={`https://steamcommunity.com/sharedfiles/filedetails/?id=${puzzleId.substring(1)}`}
-                            target="_blank"
-                            rel="noreferrer"
+                    <>
+                        <Button
+                            size="small"
+                            variant="outlined"
+                            color="primary"
                             style={{
-                                color: "inherit",
-                                textDecoration: "none",
+                                marginTop: "auto",
+                                marginBottom: "auto",
                             }}
                         >
-                            Get on Steam
-                        </a>
-                    </Button>
+                            <a
+                                href={`https://steamcommunity.com/sharedfiles/filedetails/?id=${puzzleId.substring(1)}`}
+                                target="_blank"
+                                rel="noreferrer"
+                                style={{
+                                    color: "inherit",
+                                    textDecoration: "none",
+                                }}
+                            >
+                                Get Puzle Direct
+                            </a>
+                        </Button>
+                        <Button
+                            size="small"
+                            variant="outlined"
+                            color="primary"
+                            style={{
+                                marginTop: "auto",
+                                marginBottom: "auto",
+                            }}
+                        >
+                            <a
+                                href={`https://steamcommunity.com/sharedfiles/filedetails/?id=${puzzleId.substring(1)}`}
+                                target="_blank"
+                                rel="noreferrer"
+                                style={{
+                                    color: "inherit",
+                                    textDecoration: "none",
+                                }}
+                            >
+                                Get on Steam
+                            </a>
+                        </Button>
+                    </>
                 ) : (
                     <Button
                         size="small"

--- a/web/src/views/om/puzzles/PuzzleView.tsx
+++ b/web/src/views/om/puzzles/PuzzleView.tsx
@@ -102,7 +102,7 @@ export default function PuzzleView() {
                     <LoadingIndicator />
                 )}
                 {puzzleId?.match(/w[0-9]+/) ? (
-                    <Download_Buttons>
+                    <>
                         <Button
                             size="small"
                             variant="outlined"
@@ -145,7 +145,7 @@ export default function PuzzleView() {
                                 Get on Steam
                             </a>
                         </Button>
-                    </Download_Buttons>
+                    </>
                 ) : (
                     <Button
                         size="small"

--- a/web/src/views/om/puzzles/PuzzleView.tsx
+++ b/web/src/views/om/puzzles/PuzzleView.tsx
@@ -102,7 +102,7 @@ export default function PuzzleView() {
                     <LoadingIndicator />
                 )}
                 {puzzleId?.match(/w[0-9]+/) ? (
-                    <>
+                    <Download_Buttons>
                         <Button
                             size="small"
                             variant="outlined"
@@ -121,7 +121,7 @@ export default function PuzzleView() {
                                     textDecoration: "none",
                                 }}
                             >
-                                Get Puzle Direct
+                                Download Puzzle
                             </a>
                         </Button>
                         <Button
@@ -145,7 +145,7 @@ export default function PuzzleView() {
                                 Get on Steam
                             </a>
                         </Button>
-                    </>
+                    </Download_Buttons>
                 ) : (
                     <Button
                         size="small"


### PR DESCRIPTION
Add a button in the top right corner of a puzzle view allowing for user to download the .puzzle file directly instead of going through steam.

Currently needs line 116 of web/src/views/om/puzzles/PuzzleView.tsx to be updated to link to a download of the puzzle, instead of the steam page. 